### PR TITLE
Add fastapi backend and docs

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,4 @@
+# virtualenv
+env/
+# Firebase credentials
+credentials.json

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,13 @@
+### Overview
+A prototype fastAPI backend for file upload and initiating NeRF training jobs. Supports: 
+- User authentication (OAuth2 with JWT)
+- Multi-threaded file upload to Firebase storage (easy to swap in other providers)
+- Task creation and enqueueing
+
+### Setup
+- Install dependencies: `pip install -r requirements.txt`
+- Add mock user to fake user db at `user_db.py`
+- Download and add firebase service account credentials as `credentials.json`
+- Start Uvicorn server for dev: `uvicorn main:app --reload` 
+- Start without hot reload to allow multiple worker processes: `uvicorn main:app --workers <N_WORKERS>`
+- View swagger docs and test at http://127.0.0.1:8000/docs/

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,21 @@
+import firebase_admin
+from firebase_admin import credentials, storage
+from fastapi import UploadFile
+from pathlib import Path
+import asyncio
+
+creds = credentials.Certificate("credentials.json")
+firebase_admin.initialize_app(creds)
+db = storage.bucket(f'{creds.project_id}.appspot.com')
+
+async def upload_file_to_firebase_storage(file: UploadFile, dir: Path):
+    content = await file.read()
+    blob = db.blob(str(Path(dir,file.filename)))
+    await asyncio.to_thread(blob.upload_from_string, content, content_type=file.content_type)
+    return {'blobPath': blob.path, 'message': 'Uploaded successfully'}
+
+async def upload_files_to_firebase_storage(files: list[UploadFile], dir: Path):
+    # create a new directory in the storage bucket with the user's username
+    tasks = [asyncio.create_task(upload_file_to_firebase_storage(file, dir)) for file in files]
+    res = await asyncio.gather(*tasks)
+    return {'blobPath': dir, 'nfiles': len(res), 'message': 'Job queued successfully'}

--- a/backend/fake_users_db.py
+++ b/backend/fake_users_db.py
@@ -1,0 +1,9 @@
+fake_users_db = {
+    "opencxdev": {
+        "username": "opencxdev",
+        "full_name": "Opencx Dev",
+        "email": "dev@opencx.com",
+        "hashed_password": "$2b$12$c.YLQ/eIusuummMyz8Uole9H96FnkFgTl6uda9Ei7p2ImK2K9Nyv2",
+        "disabled": False,
+    }
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Annotated, Literal, List
+from fastapi import Depends, FastAPI, HTTPException, status, UploadFile, Form
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from models import Token, TokenData, User, UserInDB, Task
+from fake_users_db import fake_users_db
+from database import upload_files_to_firebase_storage 
+import secrets
+import queue
+
+SECRET_KEY = secrets.token_urlsafe(32)
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+app = FastAPI()
+# TODO: replace with job queuing system
+jobs = queue.Queue()
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+
+def get_user(db, username: str):
+    if username in db:
+        user_dict = db[username]
+        return UserInDB(**user_dict)
+
+
+def authenticate_user(fake_db, username: str, password: str):
+    user = get_user(fake_db, username)
+    if not user:
+        return False
+    if not verify_password(password, user.hashed_password):
+        return False
+    return user
+
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=15)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(token: Annotated[str, Depends(oauth2_scheme)]):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+        token_data = TokenData(username=username)
+    except JWTError:
+        raise credentials_exception
+    user = get_user(fake_users_db, username=token_data.username)
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+async def get_current_active_user(
+    current_user: Annotated[User, Depends(get_current_user)]
+):
+    if current_user.disabled:
+        raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+@app.post("/token", response_model=Token)
+async def login_for_access_token(
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+):
+    user = authenticate_user(fake_users_db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@app.post("/upload/")
+async def upload_files(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    files: List[UploadFile],
+    method: Literal['nerfacto', 'instant-ngp', 'gaussian-splatting', 'neuralangelo'] = Form(...),
+    iters: int = Form(...),
+):
+    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    res = await upload_files_to_firebase_storage(files, Path('datasets', current_user.username, timestamp))
+    task = Task(current_user.username, res.get('blobPath'), method, iters)
+    # TODO: replace with job queuing system
+    jobs.put(task)
+    print(task)
+    return {"nfiles": len(files), "message": "Job queued successfully"}

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+
+class TokenData(BaseModel):
+    username: str | None = None
+
+
+class User(BaseModel):
+    username: str
+    email: str | None = None
+    full_name: str | None = None
+    disabled: bool | None = None
+
+
+class UserInDB(User):
+    hashed_password: str
+
+@dataclass
+class Task:
+    username: str
+    blobPath: Path
+    method: Literal['nerfacto', 'instant-ngp', 'gaussian-splatting', 'neuralangelo']
+    iters: int

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.103.0
+firebase_admin==6.2.0
+jose==1.0.0
+passlib==1.7.4
+pydantic==2.3.0


### PR DESCRIPTION
Adds a prototype fastAPI backend for file upload and initiating NeRF training jobs. Supports: 
- User authentication (OAuth2 with JWT)
- Multi-threaded file upload to Firebase storage (easy to swap in other providers)
- Task creation and enqueueing